### PR TITLE
Slow pwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,20 @@
 ## Libraries
 Arduino 1.8.15
 Teensydino 1.54
+
+
+
+# Communication interface guide (documentation in progress)
+
+There are 16 pulse width modulation (PWM) channels active and available for functions related to setting the temperature of heaters using solid state relays and thermocouple feedback. Each of the channels initializes an "SSRController" object. The object contains a state enumerator for the presently active function of the channel. This section describes how to interface with each channel by sending messages over a serial connection. 
+
+### Available commands
+- TEMP_SET 
+    - POWER_OFF
+    - RAMP
+    - CONST
+- TEMP_CUR
+- PIDP_SET
+
+
+

--- a/SSRTeensyCode/SSRTeensyCode.ino
+++ b/SSRTeensyCode/SSRTeensyCode.ino
@@ -69,7 +69,12 @@ SoftwareSerial hc(blueRx, blueTx);
 
 // Indicates which pins of the Teensy are connected to the SSR control pins/lines.
 const int numberOfRelays = 16;
+
+//for the PCB version "ssr-v1b" which is a single Teensy, 16 SSR controller prototype board with terminal block connector
 const int relayPinList[numberOfRelays] = {3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 14, 12, 18, 15, 22, 19};
+
+//for the PCB version "ssr-v2b" that is meant for 4 Teensy's
+//const int relayPinList[numberOfRelays] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 22};
 
 const String teensyID = "T1";
 String bluetoothBuffer = "";
@@ -371,6 +376,7 @@ MessageType parseChannelMessage(std::string msg, SSRController thisController) {
       return MessageType::TEMP_SET;
     } 
 
+    //set parameters of the PID loop, p, i, and d
     if(msg.substr(0,9) == "PIDP_SET=") {
       size_t commas[2];
       size_t last_comma = 9;

--- a/SSRTeensyCode/SSRTeensyCode.ino
+++ b/SSRTeensyCode/SSRTeensyCode.ino
@@ -71,12 +71,10 @@ SoftwareSerial hc(blueRx, blueTx);
 const int numberOfRelays = 16;
 const int relayPinList[numberOfRelays] = {3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 14, 12, 18, 15, 22, 19};
 
-const String teensyID = "HenrysSSRTeensy";
+const String teensyID = "T1";
 String bluetoothBuffer = "";
 
 char print_buf[250]; // For printing errors easily
-
-
 
 
 // This is class which creates a PID controller for one SSR output
@@ -226,7 +224,7 @@ class SSRController {
     // Basic control
     // The pin of the SSR
     int _pin;
-    int isrChan; //the isr channel number referenced by Slow_PWM object
+    int _isrChan; //the isr channel number referenced by Slow_PWM object
   
     // Vectors containing prior tempuratures and how far they were from the set function
     std::vector<std::tuple<float, long long>> error_record;
@@ -245,14 +243,14 @@ class SSRController {
 
     void setupPWM()
     {
-      isrChan = ISR_PWM.setPWM(_pin, PWM_Freq, 0); //initial duty cycle is 0, don't power yet
+      _isrChan = ISR_PWM.setPWM(_pin, PWM_Freq, 0); //initial duty cycle is 0, don't power yet
     }
     
     void setDutyCycle(float percentage)
     {
       duty_cycle = percentage;
       //the line in the if statement modifies the duty cycle.  
-      if(!ISR_PWM.modifyPWMChannel(isrChan, _pin, PWM_Freq, duty_cycle))
+      if(!ISR_PWM.modifyPWMChannel(_isrChan, _pin, PWM_Freq, duty_cycle))
       {
         Serial.print(F("modifyPWMChannel error on channel: "));
         Serial.println(_pin);

--- a/SSRTeensyCode/SSRTeensyCode.ino
+++ b/SSRTeensyCode/SSRTeensyCode.ino
@@ -12,14 +12,60 @@
 #include <stdio.h>
 #include <SoftwareSerial.h>
 
+
+#define USING_MICROS_RESOLUTION       true  //false
+#include "Teensy_Slow_PWM.h"
+#include <SimpleTimer.h>   // https://github.com/jfturcot/SimpleTimer
+
 // Used to indicate errors in function returns.
 #define ERROR_TEMP -6666.0
 #define EARLIEST_TIME 1577836800
 
+/////////////////////////////////////
+//Start lines for Slow PWM objects
+#if defined(__IMXRT1062__)
+  // For Teensy 4.0 and 4.1
+  // Don't change these numbers to make higher Timer freq. System can hang
+  #define HW_TIMER_INTERVAL_MS        0.01f
+  #define HW_TIMER_INTERVAL_FREQ      100000L
+#else
+  // Don't change these numbers to make higher Timer freq. System can hang
+  #define HW_TIMER_INTERVAL_MS        0.1f
+  #define HW_TIMER_INTERVAL_FREQ      10000L
+#endif
+#define USING_HW_TIMER_INTERVAL_MS        true
+volatile uint32_t startMicros = 0;
+
+//these two lines are to fix an error in the linker
+//of C, which is pretty dependent on (1) which teensyduino
+//ide you are user, whether in "Tools > Optimize" you are set
+//to "Faster", or other factors. It is related to copy constructor
+//of vectors and strings in STL. 
+unsigned __exidx_start;
+unsigned __exidx_end;
+
+
+//Timer object, selects TEENSY_TIMER_1 from hardware definitions.
+//Don't change that number unless you read the manual of TeensyTimer
+TeensyTimer ITimer(TEENSY_TIMER_1);
+
+// Init Teensy_SLOW_PWM, each can service 16 different ISR-based PWM channels
+Teensy_SLOW_PWM ISR_PWM;
+float PWM_Freq = 5.0f; //Hz
+
+void TimerHandler()
+{ 
+  ISR_PWM.run();
+}
+//End Slow PWM object setup
+////////////////////////////////////
+
+
+
 // Indicates which pins of the Teensy are connected to the serial pins of the HC-06
 const int blueRx = 0;
 const int blueTx = 1;
-SoftwareSerial hc(blueRx,blueTx);
+SoftwareSerial hc(blueRx, blueTx);
 
 // Indicates which pins of the Teensy are connected to the SSR control pins/lines.
 const int numberOfRelays = 16;
@@ -30,10 +76,22 @@ String bluetoothBuffer = "";
 
 char print_buf[250]; // For printing errors easily
 
+
+
+
 // This is class which creates a PID controller for one SSR output
 // for details on how a PID loop works read this wiki article: https://en.wikipedia.org/wiki/PID_controller
 class SSRController {
   public:
+    SSRController(){}
+    SSRController(int SSRPin)
+    {
+      _pin = SSRPin;
+      setupPWM();
+      setDutyCycle(0.0);
+    }
+    ~SSRController(){}
+
     // State indicates the type of set point function the PID controller should use.
     // CONST indicates a constant tempurature that the controller aims for
     // RAMP indicates a linear increase or decrease in tempureture
@@ -41,122 +99,83 @@ class SSRController {
     enum State { CONST, RAMP, POWER_OFF };
     State current_state = State::POWER_OFF;
     float duty_cycle = 0.0;
-  private:
-    // Constants
-    const unsigned int MAX_RECORD_SIZE = 60*2; // 2 minutes of record time
-  
-    // Basic control
-    // The pin of the SSR
-    int _pin;
-  
-    // Vectors containing prior tempuratures and how far they were from the set function
-    std::vector<std::tuple<float, long long>> error_record;
-    std::vector<std::tuple<float, long long>> temp_record;
-    
-    void setupPWM(){
-      pinMode(_pin, OUTPUT);
-      analogWriteFrequency(_pin, 5);
-    }
-    void setDutyCycle(float percentage){
-        analogWrite(_pin, round(percentage*255.0/100.0));
-        duty_cycle = percentage;
-    }
 
-    // Parameters for the set point function
-    
-    long long start_time; // In millisecond from Jan 1, 1979 GMT
-    float ramp; // In Celcius per millisecond
-    float target_temp; // In Celcius
-    float start_temp; // In Celcius
-  
-    // This indicates the users desired tempurature at every point in time
-    float set_point_func(long long time_ms){
-        switch(current_state) {
-          case State::CONST:
-            return target_temp;
-          case State::RAMP:
-            {
-            if(start_time > time_ms)
-              return start_temp;
-            int delta_t = (int)(time_ms - start_time);
-            float possible_temp = ramp*delta_t + start_temp;
-            if((possible_temp > target_temp && ramp > 0) || (possible_temp < target_temp && ramp < 0))
-              return target_temp;
-            else
-              return possible_temp;
-            }
-          case State::POWER_OFF:
-          default:
-            return ERROR_TEMP;
-        }
-    }
-
-    // Parameters for the PID loop
-    float THERMAL_MASS = 1.0; // Celcius / Jule 
-    float K_p = 30.0; // 11 * Watts per Centigrad = 11 * J/(C*s)
-    float K_i = 1.0;  // 11 * Watts per Centigrad Milliseconds = 0.011 * J/(C*s^2)
-    float K_d = 1000*2*sqrt(THERMAL_MASS*K_p);    // 11 * Watts Milliseconds per Cenrigrad = 11,000 * J/C
-    
-  public:
-    void enterNewPIDParameters(float newKP, float newKI, float newKD){
+    void enterNewPIDParameters(float newKP, float newKI, float newKD)
+    {
       K_p = newKP;
       K_i = newKI;
       K_d = newKD;
     }
-    void enterNewSetPoint(State newState, float newTarget, float newRamp, long long newStartTime, float newStartTemp){
+    
+    void enterNewSetPoint(State newState, float newTarget, float newRamp, long long newStartTime, float newStartTemp)
+    {
       if (newState == State::POWER_OFF)
+      {
         setDutyCycle(0.0);
+      }
+      
       current_state = newState;
       target_temp = newTarget;
       ramp = newRamp;
       start_time = newStartTime;
       start_temp = newStartTemp;
     }
-    void enterNewTemp(float temp, long long time_ms){
-        if(temp_record.size() > MAX_RECORD_SIZE){
-          temp_record.erase(temp_record.begin());
-          error_record.erase(error_record.begin());
-        }
-          
-        temp_record.push_back(std::tuple<float, long long>(temp, time_ms));
-//        Serial.print("New temp added ");
-//        Serial.println(temp);
-        if(current_state != State::POWER_OFF){
-          float set_point_temp = set_point_func(time_ms);
-          float error = set_point_temp - temp;
-          error_record.push_back(std::tuple<float, long long>(error, time_ms));
-//          sprintf(print_buf, "New Record\terror: %f\ttemp: %f\tset point: %f", error, temp, set_point_temp);
-//          Serial.println(print_buf);
-        } else {
-          error_record.push_back(std::tuple<float, long long>(0.0, time_ms));
-        }
+    
+    void enterNewTemp(float temp, long long time_ms)
+    {
+      if(temp_record.size() > MAX_RECORD_SIZE)
+      {
+        temp_record.erase(temp_record.begin());
+        error_record.erase(error_record.begin());
+      }
+        
+      temp_record.push_back(std::tuple<float, long long>(temp, time_ms));
+      //        Serial.print("New temp added ");
+      //        Serial.println(temp);
+      if(current_state != State::POWER_OFF){
+        float set_point_temp = set_point_func(time_ms);
+        float error = set_point_temp - temp;
+        error_record.push_back(std::tuple<float, long long>(error, time_ms));
+      //          sprintf(print_buf, "New Record\terror: %f\ttemp: %f\tset point: %f", error, temp, set_point_temp);
+      //          Serial.println(print_buf);
+      } else {
+        error_record.push_back(std::tuple<float, long long>(0.0, time_ms));
+      }
     }
-    void updatePID() {
-      if(current_state == State::POWER_OFF){
+
+    
+    void updatePID()
+    {
+      if(current_state == State::POWER_OFF)
+      {
         setDutyCycle(0.0);
         return;
       }
-        
+    
       int record_length = error_record.size();
-      
+    
       if(record_length < 2)
+      {
         return;
-
+      } 
+    
       float proportional = std::get<0>(error_record[record_length-1]);
-        
+    
       float integral = 0;
-      for(int i = 1; i < record_length; i++){
+      for(int i = 1; i < record_length; i++)
+      {
         std::tuple<float, long long> prev_error = error_record[i-1];
         std::tuple<float, long long> curr_error = error_record[i];
         float average_temp = (std::get<0>(curr_error) + std::get<0>(prev_error))/2.0;
         long long delta_t = std::get<1>(curr_error) - std::get<1>(prev_error);
-//        sprintf(print_buf, "Average error: %f, delta t: %lld", average_temp, delta_t);
-//        Serial.println(print_buf);
-        if(delta_t > 60*1000 || delta_t < 0){
+        //        sprintf(print_buf, "Average error: %f, delta t: %lld", average_temp, delta_t);
+        //        Serial.println(print_buf);
+        if(delta_t > 60*1000 || delta_t < 0)
+        {
           Serial.print("ERROR: Invalid time difference: ");
-          Serial.println(delta_t);
-          Serial.println(std::get<1>(curr_error));
-          Serial.println(std::get<1>(prev_error));
+          //Serial.println(delta_t);
+          //Serial.println(std::get<1>(curr_error));
+          //Serial.println(std::get<1>(prev_error));
           error_record.erase(error_record.begin() + i - 1);
           temp_record.erase(temp_record.begin() + i - 1);
           error_record.erase(error_record.begin() + i);
@@ -166,49 +185,119 @@ class SSRController {
         }
         integral += average_temp*delta_t;
       }
-      
-//      sprintf(print_buf, "Total integral: %f Total time: %lld", integral, std::get<1>(error_record[record_length-1]) - std::get<1>(error_record[0]));
-//      Serial.println(print_buf);
+    
+      //      sprintf(print_buf, "Total integral: %f Total time: %lld", integral, std::get<1>(error_record[record_length-1]) - std::get<1>(error_record[0]));
+      //      Serial.println(print_buf);
       integral = integral/(std::get<1>(error_record[record_length-1]) - std::get<1>(error_record[0]));
-      
+    
       std::tuple<float, long long> prev_error = error_record[record_length - 2];
       std::tuple<float, long long> curr_error = error_record[record_length - 1];
-
+    
       int time_delta = std::get<1>(curr_error) - std::get<1>(prev_error);
       float derivative = 0;
       if(time_delta > 0)
-        derivative = (std::get<0>(curr_error) - std::get<0>(prev_error))/time_delta;
-
+      {
+        derivative = (std::get<0>(curr_error) - std::get<0>(prev_error))/time_delta;  
+      }
+      
+    
       float u = K_p*proportional + K_i*integral + K_d*derivative;
       if(u > 100.0)
+      {
         u = 100.0;
+      }
+      
       else if (u < 0.0)
+      {
         u = 0.0;
-
+      }
+      
+    
       sprintf(print_buf, "PID out put was : %f\n\nType\tError\tScaled\nP:\t%f\t%f\nI:\t%f\t%f\nD:\t%f\t%f", u, proportional, K_p*proportional, integral, K_i*integral, derivative, K_d*derivative);
       Serial.println(print_buf);
-
       setDutyCycle(u);
     }
-    SSRController(int SSRPin) {
-        _pin = SSRPin;
-        setupPWM();
-        setDutyCycle(0.0);
+
+    
+  private:
+    // Constants
+    const unsigned int MAX_RECORD_SIZE = 60*2; // 2 minutes of record time
+ 
+    // Basic control
+    // The pin of the SSR
+    int _pin;
+    int isrChan; //the isr channel number referenced by Slow_PWM object
+  
+    // Vectors containing prior tempuratures and how far they were from the set function
+    std::vector<std::tuple<float, long long>> error_record;
+    std::vector<std::tuple<float, long long>> temp_record;
+
+    long long start_time; // In millisecond from Jan 1, 1979 GMT
+    float ramp; // In Celcius per millisecond
+    float target_temp; // In Celcius
+    float start_temp; // In Celcius
+
+    // Parameters for the PID loop
+    float THERMAL_MASS = 1.0; // Celcius / Jule 
+    float K_p = 30.0; // 11 * Watts per Centigrad = 11 * J/(C*s)
+    float K_i = 1.0;  // 11 * Watts per Centigrad Milliseconds = 0.011 * J/(C*s^2)
+    float K_d = 1000*2*sqrt(THERMAL_MASS*K_p);    // 11 * Watts Milliseconds per Cenrigrad = 11,000 * J/C
+
+    void setupPWM()
+    {
+      isrChan = ISR_PWM.setPWM(_pin, PWM_Freq, 0); //initial duty cycle is 0, don't power yet
     }
+    
+    void setDutyCycle(float percentage)
+    {
+      duty_cycle = percentage;
+      //the line in the if statement modifies the duty cycle.  
+      if(!ISR_PWM.modifyPWMChannel(isrChan, _pin, PWM_Freq, duty_cycle))
+      {
+        Serial.print(F("modifyPWMChannel error on channel: "));
+        Serial.println(_pin);
+      }
+    }
+    
+    float set_point_func(long long time_ms)
+    {
+      switch(current_state) 
+      {
+        case State::CONST:
+        return target_temp;
+        case State::RAMP:
+        {
+          if(start_time > time_ms) 
+          {
+            return start_temp;
+          }
+          int delta_t = (int)(time_ms - start_time);
+          float possible_temp = ramp*delta_t + start_temp;
+          if((possible_temp > target_temp && ramp > 0) || (possible_temp < target_temp && ramp < 0))
+          {
+            return target_temp;
+          }
+          else
+          {
+            return possible_temp;
+          }
+        }
+        case State::POWER_OFF:
+        default:
+        return ERROR_TEMP;
+      }
+    }  
 };
+
+
 
 // A vector of SSR controller to allow the teensy to control multiple channels.
 std::vector<SSRController> Controllers;
 
-
-// Message Type indicates the type of message sent from the bluetooth module
-// NONE indicates some sort of error
-// TEMP_SET indicates a comand to set the PID controller set point function for one SSR
-// TEMP_CUR indicates the tempurature recorded and the time it was recorded.
-enum MessageType { NONE, TEMP_SET, TEMP_CUR };
-
 std::string firstHalfOfSplitMessage(""); // HC06 will send data at random time intervals so sometimes messages will be 
 // cutoff at the end of one buffer and continue at the start of the next.  This string stores the cut off message so it can be recombined.
+
+
 
 int count_substring(std::string s, std::string target){
   int occurrences = 0;
@@ -219,6 +308,15 @@ int count_substring(std::string s, std::string target){
   }
   return occurrences;
 }
+
+
+// Message Type indicates the type of message sent from the bluetooth module
+// NONE indicates some sort of error
+// TEMP_SET indicates a comand to set the PID controller set point function for one SSR
+// TEMP_CUR indicates the tempurature recorded and the time it was recorded.
+enum MessageType { NONE, TEMP_SET, TEMP_CUR };
+
+MessageType parseChannelMessage(std::string msg, SSRController thisController);
 
 MessageType parseChannelMessage(std::string msg, SSRController thisController) {
   if(count_substring(msg, std::string("TEMP_SET=")) + count_substring(msg, std::string("TEMP_CUR=")) > 1){
@@ -320,6 +418,8 @@ MessageType parseChannelMessage(std::string msg, SSRController thisController) {
     return MessageType::NONE;
 }
 
+MessageType parseBluetoothMessage(std::string msg);
+
 MessageType parseBluetoothMessage(std::string msg){
     if (msg[0] != '#'){
       sprintf(print_buf, "ERROR: received message without opening hashtag: %s", msg.c_str());
@@ -392,10 +492,7 @@ void parseBluetoothBuffer(String bluetoothBuffer){
 // Initialize all of pins need, the serial channel for connecting to the HC-06 bluetooth module,
 // and initialize a normal serial output for debuging
 void setup()   {  
-  for(int i = 0; i < numberOfRelays; i++) {
-    Controllers.push_back(SSRController(relayPinList[i]));              
-  }
-
+  //setup bluetooth communication
   hc.begin(9600);
   while(hc.available())
   {
@@ -405,6 +502,39 @@ void setup()   {
   Serial.begin(9600);
   Serial.println("Testing Magis SSR");
   Serial.println(teensyID);
+
+  ////////////////////////////////
+  //Setup associated with Slow PWM
+  #if USING_HW_TIMER_INTERVAL_MS
+    // Interval in microsecs
+    if (ITimer.attachInterruptInterval(HW_TIMER_INTERVAL_MS * 1000, TimerHandler))
+    {
+      startMicros = micros();
+      Serial.print(F("Starting ITimer OK, micros() = ")); Serial.println(startMicros);
+    }
+    else
+      Serial.println(F("Can't set ITimer correctly. Select another freq. or interval"));
+      
+  #else
+  
+    if (ITimer.attachInterrupt(HW_TIMER_INTERVAL_FREQ, TimerHandler))
+    {
+      Serial.print(F("Starting  ITimer OK, micros() = ")); Serial.println(micros());
+    }
+    else
+      Serial.println(F("Can't set ITimer. Select another freq. or timer"));
+      
+  #endif
+  //End Slow PWM setup
+  ////////////////////////////////
+
+  //this SSRController construction initializes the ISR_PWM channels, calling setPWM. 
+  //(thus must come after the ISR_PWM setup above). 
+  for(int i = 0; i < numberOfRelays; i++) {
+    Controllers.push_back(SSRController(relayPinList[i]));              
+  }
+
+  
 }
 
 bool heartbeat = true;


### PR DESCRIPTION
Slow PWM incorporates the Teensy_Slow_PWM library into the firmware so that the clock of the Teensy does not need modification in order to reach 5Hz PWM periods. At the point of this pull request, Sergei has tested an identical code configuration for the Slow_PWM functionality but outside of the framework of this firmware (i.e. in a manual-mode control firmware that he made). 

Another change is that some of the functions have been cleaned up with tabification and reordering of class modules. This came from Evan having some compilation issues and wanting to clean the code up to figure it out. 

A documentation Readme has also been added but is in progress. 